### PR TITLE
First refactor of composed schedules

### DIFF
--- a/src/level1/dot.py
+++ b/src/level1/dot.py
@@ -37,6 +37,7 @@ def dot_template(n: size, x: [R][n], y: [R][n], result: R):
 def schedule_dot_stride_1(dot, params):
     dot = generate_stride_1_proc(dot, params.precision)
     main_loop = dot.find_loop("i")
+    dot = stage_mem(dot, dot.body(), "result", "result_")
     dot = blas_vectorize(dot, main_loop, params)
     return simplify(dot)
 

--- a/src/level1/rot.py
+++ b/src/level1/rot.py
@@ -61,13 +61,9 @@ def schedule_rot_stride_1(VEC_W, INTERLEAVE_FACTOR, memory, instructions, precis
         simple_stride_1, simple_stride_1.find_loop("io"), INTERLEAVE_FACTOR
     )
 
-    regs_to_hoist = ["reg3", "reg2", "sReg", "reg11", "cReg", "reg4"]
-    stmts_to_hoist = ["c", "s", "reg2[_]", "-sReg[_]", "reg3[_]", "cReg[_]"]
-    for reg in regs_to_hoist:
-        simple_stride_1 = lift_alloc(simple_stride_1, reg)
-    for stmt in stmts_to_hoist:
-        loop = simple_stride_1.find(stmt).parent().parent()
-        simple_stride_1 = hoist_stmt(simple_stride_1, loop)
+    simple_stride_1 = apply_to_block(
+        simple_stride_1, simple_stride_1.forward(loop_cursor).body(), hoist_stmt
+    )
 
     simple_stride_1 = replace_all(simple_stride_1, instructions)
 

--- a/src/level2/trmv.py
+++ b/src/level2/trmv.py
@@ -194,7 +194,9 @@ def schedule_trmv_row_major_vectorize_reuse_over_rows(
         dot_alloc = trmv.find("dot : _")
         trmv = set_memory(trmv, "dot", DRAM_STATIC)
         trmv = unroll_loop(trmv, trmv.find_loop("ii"))
-    return simplify(trmv)
+    trmv = simplify(trmv)
+
+    return trmv
 
 
 template_sched_list = [

--- a/src/level3/syrk.py
+++ b/src/level3/syrk.py
@@ -786,7 +786,6 @@ class SYRK:
             n_lifts=1,
         )
         diag_syrk_scheduled = simplify(diag_syrk_scheduled)
-        print(diag_syrk_scheduled)
         diag_syrk_scheduled = reorder_loops(diag_syrk_scheduled, "iii jio")
         diag_syrk_scheduled = replace(
             diag_syrk_scheduled,
@@ -830,8 +829,6 @@ class SYRK:
             )
             microkernel_diag_base = microkernel_diag_handler.base_microkernel
             microkernel_diag_scheduled = microkernel_diag_handler.scheduled_microkernel
-            print(diag_syrk_scheduled)
-            print(unsafe_microkernel_base)
             # print(microkernel_diag_scheduled)
 
             @proc
@@ -895,7 +892,6 @@ class SYRK:
             #    avx2_mask_storeu_ps,
             # )
             # unsafe_microkernel_scheduled = reorder_loops(unsafe_microkernel_scheduled, "io iio")
-            print(unsafe_microkernel_scheduled)
 
             # unsafe_microkernel_scheduled = unsafe_microkernel_scheduled.partial_eval(M=microkernel_diag_handler.M_r, N=)
 


### PR DESCRIPTION
Refactored parallelize_reduction

Previously, this operations was over parametrized to allow generating multiple accumulators for doing the same reduction. However, with the insight that that getting multiple accumulators can be obtained by again parallelizing the already parallelized accumulator, then you can simplify a lot of the code. Moreover, this generates code that add up the various accumulators out of the main loop (which can be done as vector add) and then one vector reduce add. While previously, we endup having to do N reduce_add.