### PR TITLE
Change Google benchmark from required to quiet

### DIFF
--- a/.github/workflows/avx2.yml
+++ b/.github/workflows/avx2.yml
@@ -27,9 +27,6 @@ jobs:
     - name: Install Ninja and git
       run: sudo apt install ninja-build git
 
-    - name: Install Google benchmark
-      run: git clone https://github.com/google/benchmark; cmake -S benchmark -B benchmark/build -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_TESTING=NO ; cmake --build benchmark/build; cmake --install benchmark/build --prefix ~/.local
-
     - name: Install Exo
       run: git clone https://github.com/exo-lang/exo.git ; cd exo; git checkout main; python -m pip install build ; python -m build . ; python -m pip install dist/*.whl
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(
 ##
 # Google Benchmark
 
-find_package(benchmark REQUIRED)
+find_package(benchmark QUIET)
 
 ## Python
 find_package(Python 3 REQUIRED Interpreter)


### PR DESCRIPTION
Since funcitonal correctness tests in CI shouldn't require Gbench